### PR TITLE
Add LD_LIBRARY_PATH environment variable to WSGI script

### DIFF
--- a/crf2/wsgi.py
+++ b/crf2/wsgi.py
@@ -12,5 +12,6 @@ import os
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crf2.settings')
+os.environ['LD_LIBRARY_PATH'] = '/usr/local/lib'
 
 application = get_wsgi_application()


### PR DESCRIPTION
We're switching to using [mod_wsgi](https://modwsgi.readthedocs.io/en/develop/) instead gunicorn to integrate more securely with Shibboleth. We were previously setting this env var in the Supervisor config but we don't need that anymore! ✂️ We could set it per-request with mod_wsgi but it shouldn't ever change. Open to moving this somewhere more Django-ish or environment-config-y if it makes more sense!